### PR TITLE
fix(README.rst): correct SPDX specification links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -216,12 +216,12 @@ Add something to the SBOM.
 
 ``FILETYPE``
    The SPDX File Type.
-   Refer to the `SPDX specification <SPDX>`_.
+   Refer to the `SPDX specification <https://spdx.github.io/spdx-spec/v2.3>`_.
 
 ``RELATIONSHIP``
    A relationship definition related to this file.
    The string ``@SBOM_LAST_SPDXID@`` will be replaced by the SPDXID that is used for this SBOM item.
-   Refer to the `SPDX specification <SPDX>`_.
+   Refer to the `SPDX specification <https://spdx.github.io/spdx-spec/v2.3>`_.
 
 ``SPDXID``
    The ID to use for identifier generation.


### PR DESCRIPTION
Looks like a few of the SPDX specification links used to point to a local version of them which no longer exists. This updates the links to where the rest of the README links to.